### PR TITLE
Upgrade to hdf5 1.8.18

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,12 +10,12 @@ source:
     sha256: 78a019adb4fe42318832010e9a2b071761a56101291185c0c16e7368ccca01fc 
 
 build:
-  number: 2
+  number: 3
   skip: True  # [win] 
 
 requirements:
   build:
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - libnetcdf 4.4.*
     - jasper
     - g2clib
@@ -25,7 +25,7 @@ requirements:
     - libdrs
     - toolchain  # [osx]
   run:
-    - hdf5 1.8.17|1.8.17.*
+    - hdf5 1.8.18|1.8.18.*
     - libnetcdf 4.4.*
     - jasper
     - g2clib


### PR DESCRIPTION
A few CVEs were reported and fixed in hdf5 back in November 2016: http://blog.talosintelligence.com/2016/11/hdf5-vulns.html

The hdf5 release notes for that release are available here: https://support.hdfgroup.org/ftp/HDF5/current18/src/hdf5-1.8.18-RELEASE.txt

For additional info, please see: https://github.com/conda-forge/hdf5-feedstock/pull/68 and https://github.com/conda-forge/hdf5-feedstock/issues/71